### PR TITLE
Adds Travis CI build status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Maintainability](https://api.codeclimate.com/v1/badges/345bb65f72680e693aca/maintainability)](https://codeclimate.com/github/randalhumphries/hr_app/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/345bb65f72680e693aca/test_coverage)](https://codeclimate.com/github/randalhumphries/hr_app/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/345bb65f72680e693aca/maintainability)](https://codeclimate.com/github/randalhumphries/hr_app/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/345bb65f72680e693aca/test_coverage)](https://codeclimate.com/github/randalhumphries/hr_app/test_coverage) [![Build Status](https://travis-ci.org/randalhumphries/hr_app.svg?branch=master)](https://travis-ci.org/randalhumphries/hr_app)
 
 # HR App
 


### PR DESCRIPTION
Why:

* Provide notice of current build status

This change addresses the need by:

* Adding Travis CI build status badge to README.md